### PR TITLE
Fix(Google Refresh Token): Requisição de login quando o refresh token expirar

### DIFF
--- a/src/constants/api/APIWebSocketDestConstants.ts
+++ b/src/constants/api/APIWebSocketDestConstants.ts
@@ -19,6 +19,7 @@ class APIWebSocketDestConstants {
 	USER = 'user'
 	USER_SETTINGS = 'user_settings'
 	GOOGLE_SCOPE = 'google_scope'
+	LOGOUT_REQUEST = 'logout_request'
 }
 
 export default new APIWebSocketDestConstants()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,12 +4,15 @@ import * as ServiceWorker from './serviceWorker'
 import AlertProvider from './context/alert'
 import EventService from './services/events/EventService'
 import GoogleOAuth2Provider from './context/google_oauth2'
-import App from './App'
 import LanguageProvider from './context/language'
+import LogoutService from './services/auth/LogoutService'
+import App from './App'
 import './Var.css'
+
 
 window.addEventListener('load', () => {
 	EventService.whenStart()
+	LogoutService.start()
 })
 
 ReactDOM.render(

--- a/src/services/auth/LogoutService.ts
+++ b/src/services/auth/LogoutService.ts
@@ -22,7 +22,6 @@ class LogoutService extends WebSocketSubscriberableService {
   }
 
   private webSocketCallback = async (model: LogoutMessage | undefined) => {
-    console.log("oi")
     AuthService.logout()
 	}
 }

--- a/src/services/auth/LogoutService.ts
+++ b/src/services/auth/LogoutService.ts
@@ -1,0 +1,30 @@
+import APIWebSocketDestConstants from "../../constants/api/APIWebSocketDestConstants"
+import LogoutMessage from "../../types/auth/api/LogoutMessage"
+import WebSocketSubscriber from "../../types/web_socket/WebSocketSubscriber"
+import WebSocketQueuePathService from "../websocket/path/WebSocketQueuePathService"
+import WebSocketSubscriberableService from "../websocket/WebSocketSubscriberableService"
+import AuthService from "./AuthService"
+
+class LogoutService extends WebSocketSubscriberableService {
+  public start() {}
+
+  protected getWebSocketSubscribers(): WebSocketSubscriber<LogoutMessage>[] {
+    return [
+			{
+				path: WebSocketQueuePathService.generateDestinationPath(APIWebSocketDestConstants.LOGOUT_REQUEST), 
+				callback: this.webSocketCallback,
+			},
+		]
+  }
+
+  protected getWebSocketDependencies(): WebSocketSubscriberableService[] {
+    return []
+  }
+
+  private webSocketCallback = async (model: LogoutMessage | undefined) => {
+    console.log("oi")
+    AuthService.logout()
+	}
+}
+
+export default new LogoutService()

--- a/src/services/auth/google/GoogleScopeService.ts
+++ b/src/services/auth/google/GoogleScopeService.ts
@@ -8,7 +8,7 @@ import SynchronizableWSDeleteModel from '../../../types/sync/api/web_socket/Sync
 import GoogleScope from '../../../types/auth/google/GoogleScope'
 import GoogleAgentService from '../../../agent/GoogleAgentService'
 import SynchronizableService from '../../sync/SynchronizableService'
-import WebSocketQueueURLService from '../../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../../websocket/path/WebSocketQueuePathService'
 import Database from '../../../storage/Database'
 
 class GoogleScopeServiceImpl extends AutoSynchronizableService<
@@ -20,7 +20,7 @@ class GoogleScopeServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.googleScope,
 			APIRequestMappingConstants.GOOGLE_SCOPE,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.GOOGLE_SCOPE,
 		)
 	}

--- a/src/services/contact/ContactService.ts
+++ b/src/services/contact/ContactService.ts
@@ -10,7 +10,7 @@ import ContactView from '../../types/contact/view/ContactView'
 import SynchronizableService from '../sync/SynchronizableService'
 import PhoneService from './PhoneService'
 import GoogleContactService from './GoogleContactService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import Database from '../../storage/Database'
 import EssentialContactService from './EssentialContactService'
 import Utils from '../../utils/Utils'
@@ -24,7 +24,7 @@ class ContactServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.contact,
 			APIRequestMappingConstants.CONTACT,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.CONTACT,
 		)
 	}

--- a/src/services/contact/GoogleContactService.ts
+++ b/src/services/contact/GoogleContactService.ts
@@ -6,7 +6,7 @@ import APIRequestMappingConstants from '../../constants/api/APIRequestMappingCon
 import APIWebSocketDestConstants from '../../constants/api/APIWebSocketDestConstants'
 import ContactEntity from '../../types/contact/database/ContactEntity'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import Database from '../../storage/Database'
 import Utils from '../../utils/Utils'
 import PhoneService from './PhoneService'
@@ -20,7 +20,7 @@ class GoogleContactServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.googleContact,
 			APIRequestMappingConstants.GOOGLE_CONTACT,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.GOOGLE_CONTACT,
 		)
 	}

--- a/src/services/contact/PhoneService.ts
+++ b/src/services/contact/PhoneService.ts
@@ -10,7 +10,7 @@ import AutoSynchronizableService from '../sync/AutoSynchronizableService'
 import ContactService from './ContactService'
 import ContactView from '../../types/contact/view/ContactView'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import Database from '../../storage/Database'
 import EssentialContactService from './EssentialContactService'
 import Utils from '../../utils/Utils'
@@ -24,7 +24,7 @@ export class PhoneServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.phone,
 			APIRequestMappingConstants.PHONE,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.PHONE,
 		)
 	}

--- a/src/services/faq/FaqItemService.ts
+++ b/src/services/faq/FaqItemService.ts
@@ -7,7 +7,7 @@ import StringUtils from '../../utils/StringUtils'
 import FaqEntity from '../../types/faq/database/FaqEntity'
 import FaqService from './FaqService'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketTopicURLService from '../websocket/path/WebSocketTopicPathService'
+import WebSocketTopicPathService from '../websocket/path/WebSocketTopicPathService'
 import Database from '../../storage/Database'
 
 class FaqItemServiceImpl extends AutoSynchronizableService<
@@ -19,7 +19,7 @@ class FaqItemServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.faqItem,
 			APIRequestMappingConstants.FAQ_ITEM,
-			WebSocketTopicURLService,
+			WebSocketTopicPathService,
 			APIWebSocketDestConstants.FAQ_ITEM,
 		)
 	}

--- a/src/services/faq/FaqService.ts
+++ b/src/services/faq/FaqService.ts
@@ -9,7 +9,7 @@ import FaqItemService from './FaqItemService'
 import TreatmentEntity from '../../types/treatment/database/TreatmentEntity'
 import TreatmentService from '../treatment/TreatmentService'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketTopicURLService from '../websocket/path/WebSocketTopicPathService'
+import WebSocketTopicPathService from '../websocket/path/WebSocketTopicPathService'
 import Database from '../../storage/Database'
 
 class FaqServiceImpl extends AutoSynchronizableService<
@@ -21,7 +21,7 @@ class FaqServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.faq,
 			APIRequestMappingConstants.FAQ,
-			WebSocketTopicURLService,
+			WebSocketTopicPathService,
 			APIWebSocketDestConstants.FAQ,
 		)
 	}

--- a/src/services/faq/FaqUserQuestionService.ts
+++ b/src/services/faq/FaqUserQuestionService.ts
@@ -5,7 +5,7 @@ import APIRequestMappingConstants from '../../constants/api/APIRequestMappingCon
 import APIWebSocketDestConstants from '../../constants/api/APIWebSocketDestConstants'
 import FaqService from './FaqService'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import Database from '../../storage/Database'
 
 class FaqUserQuestionServiceImpl extends AutoSynchronizableService<
@@ -17,7 +17,7 @@ class FaqUserQuestionServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.faqUserQuestion,
 			APIRequestMappingConstants.FAQ_USER_QUESTION,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.FAQ_USER_QUESTION,
 		)
 	}

--- a/src/services/glossary/GlossaryService.ts
+++ b/src/services/glossary/GlossaryService.ts
@@ -5,7 +5,7 @@ import GlossaryItemDataModel from '../../types/glossary/api/GlossaryItemDataMode
 import GlossaryItemEntity from '../../types/glossary/database/GlossaryItemEntity'
 import APIWebSocketDestConstants from '../../constants/api/APIWebSocketDestConstants'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketTopicURLService from '../websocket/path/WebSocketTopicPathService'
+import WebSocketTopicPathService from '../websocket/path/WebSocketTopicPathService'
 import Database from '../../storage/Database'
 import StringUtils from '../../utils/StringUtils'
 
@@ -18,7 +18,7 @@ class GlossaryServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.glossary,
 			APIRequestMappingConstants.GLOSSARY,
-			WebSocketTopicURLService,
+			WebSocketTopicPathService,
 			APIWebSocketDestConstants.GLOSSARY,
 		)
 	}

--- a/src/services/note/NoteColumnService.ts
+++ b/src/services/note/NoteColumnService.ts
@@ -7,7 +7,7 @@ import NoteEntity from '../../types/note/database/NoteEntity'
 import NoteView from '../../types/note/view/NoteView'
 import AutoSynchronizableService from '../sync/AutoSynchronizableService'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import NoteService from './NoteService'
 
 class NoteColumnServiceImpl extends AutoSynchronizableService<
@@ -19,7 +19,7 @@ class NoteColumnServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.noteColumn,
 			APIRequestMappingConstants.NOTE_COLUMN,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.NOTE_COLUMN,
 		)
 	}

--- a/src/services/note/NoteService.ts
+++ b/src/services/note/NoteService.ts
@@ -8,7 +8,7 @@ import NoteEntity from '../../types/note/database/NoteEntity'
 import ArrayUtils from '../../utils/ArrayUtils'
 import AutoSynchronizableService from '../sync/AutoSynchronizableService'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import NoteColumnService from './NoteColumnService'
 import NoteView from '../../types/note/view/NoteView'
 import Utils from '../../utils/Utils'
@@ -22,7 +22,7 @@ class NoteServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.note,
 			APIRequestMappingConstants.NOTE,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.NOTE,
 		)
 	}

--- a/src/services/treatment/TreatmentService.ts
+++ b/src/services/treatment/TreatmentService.ts
@@ -4,7 +4,7 @@ import APIWebSocketDestConstants from '../../constants/api/APIWebSocketDestConst
 import TreatmentDataModel from '../../types/treatment/api/TreatmentDataModel'
 import TreatmentEntity from '../../types/treatment/database/TreatmentEntity'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketTopicURLService from '../websocket/path/WebSocketTopicPathService'
+import WebSocketTopicPathService from '../websocket/path/WebSocketTopicPathService'
 import Database from '../../storage/Database'
 
 class TreatmentServiceImpl extends AutoSynchronizableService<
@@ -16,7 +16,7 @@ class TreatmentServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.treatment,
 			APIRequestMappingConstants.TREATMENT,
-			WebSocketTopicURLService,
+			WebSocketTopicPathService,
 			APIWebSocketDestConstants.TREATMENT,
 		)
 	}

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -9,7 +9,7 @@ import GooglePhotoResponseModel from '../../types/google_api/people/GooglePhotos
 import GoogleUserService from './GoogleUserService'
 import GooglePeopleAPIUtils from '../../utils/GooglePeopleAPIUtils'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import Database from '../../storage/Database'
 import Utils from '../../utils/Utils'
 
@@ -22,7 +22,7 @@ class UserServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.user,
 			APIRequestMappingConstants.USER,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.USER,
 		)
 	}

--- a/src/services/user/UserSettingsService.ts
+++ b/src/services/user/UserSettingsService.ts
@@ -12,7 +12,7 @@ import FontSizeEnum from '../../types/user/view/FontSizeEnum'
 import OptionType from '../../types/user/view/OptionType'
 import TreatmentEntity from '../../types/treatment/database/TreatmentEntity'
 import SynchronizableService from '../sync/SynchronizableService'
-import WebSocketQueueURLService from '../websocket/path/WebSocketQueuePathService'
+import WebSocketQueuePathService from '../websocket/path/WebSocketQueuePathService'
 import Database from '../../storage/Database'
 import GoogleScopeService from '../auth/google/GoogleScopeService'
 import LanguageEnum from '../../types/user/view/LanguageEnum'
@@ -26,7 +26,7 @@ class UserSettingsServiceImpl extends AutoSynchronizableService<
 		super(
 			Database.userSettings,
 			APIRequestMappingConstants.USER_SETTINGS,
-			WebSocketQueueURLService,
+			WebSocketQueuePathService,
 			APIWebSocketDestConstants.USER_SETTINGS,
 		)
 	}

--- a/src/services/websocket/WebSocketService.ts
+++ b/src/services/websocket/WebSocketService.ts
@@ -31,7 +31,7 @@ class WebSocketService {
 					const baseUrl = this.getSocketBaseURL(responseData.webSocketToken)
 					this.socket = new SockJS(baseUrl)
 					this.stompClient = Stomp.over(this.socket)
-					this.muteConnectionLogs()
+					//this.muteConnectionLogs()
 					this.stompClient.connect({}, this.subscribe)
 					this.socket.onclose = () => {
 						this.handleWebSocketClosed()

--- a/src/services/websocket/path/WebSocketQueuePathService.ts
+++ b/src/services/websocket/path/WebSocketQueuePathService.ts
@@ -1,9 +1,9 @@
 import WebSocketURLService from './WebSocketPathService'
 
-class WebSocketQueueURLService implements WebSocketURLService {
+class WebSocketQueuePathService implements WebSocketURLService {
 	generateDestinationPath = (dest: string) => {
 		return '/user/queue/' + dest
 	}
 }
 
-export default new WebSocketQueueURLService()
+export default new WebSocketQueuePathService()

--- a/src/services/websocket/path/WebSocketTopicPathService.ts
+++ b/src/services/websocket/path/WebSocketTopicPathService.ts
@@ -1,9 +1,9 @@
 import WebSocketURLService from './WebSocketPathService'
 
-class WebSocketTopicURLService implements WebSocketURLService {
+class WebSocketTopicPathService implements WebSocketURLService {
 	generateDestinationPath = (dest: string) => {
 		return '/topic/' + dest
 	}
 }
 
-export default new WebSocketTopicURLService()
+export default new WebSocketTopicPathService()

--- a/src/types/auth/api/LogoutMessage.ts
+++ b/src/types/auth/api/LogoutMessage.ts
@@ -1,0 +1,3 @@
+export default interface LogoutMessage {
+  message: string
+}


### PR DESCRIPTION
O refresh token utilizado para requisitar novos tokens de acesso ao Google pode vir a expirar. Quando expirado a API irá disparar uma mensagem para logout dos dispositivos.